### PR TITLE
Enhance login with registration form

### DIFF
--- a/QuicksportsApp/LoginView.swift
+++ b/QuicksportsApp/LoginView.swift
@@ -9,47 +9,35 @@ import SwiftUI
 struct LoginView: View {
     @AppStorage("isLoggedIn") private var isLoggedIn = false
 
+    // Registration state
+    @State private var showRegistration = false
+
+    // Registration fields (left blank by default)
+    @State private var fullName = ""
+    @State private var email = ""
+    @State private var password = ""
+    @State private var likedSport = ""
+    @State private var sportLevel = ""
+    @State private var agreeTerms = false
+    @State private var subscribeNews = false
+
     var body: some View {
         ZStack {
-            // Background image (with logo already inside)
+            // Background image with app branding
             Image("LoginBackground")
                 .resizable()
                 .scaledToFill()
                 .ignoresSafeArea()
 
-            // White rounded panel with login controls
+            // White rounded panel with controls
             VStack {
                 Spacer()
 
-                VStack(spacing: 16) {
-                    Text("Log in to The QuickSport")
-                        .font(.headline)
-                        .foregroundColor(.black)
-
-                    Button(action: {
-                        isLoggedIn = true
-                    }) {
-                        HStack {
-                            Image(systemName: "globe")
-                            Text("Log in with Google")
-                        }
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background(Color(.systemGray6))
-                        .cornerRadius(10)
-                    }
-
-                    Divider()
-
-                    Button(action: {
-                        isLoggedIn = true
-                    }) {
-                        Text("Log in")
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(Color.blue)
-                            .foregroundColor(.white)
-                            .cornerRadius(10)
+                Group {
+                    if showRegistration {
+                        registrationForm
+                    } else {
+                        loginControls
                     }
                 }
                 .padding()
@@ -58,6 +46,77 @@ struct LoginView: View {
                 .padding()
 
                 Spacer().frame(height: 40)
+            }
+        }
+    }
+
+    // Simple login view with two options
+    private var loginControls: some View {
+        VStack(spacing: 16) {
+            Text("Welcome to QuickSport")
+                .font(.headline)
+                .foregroundColor(.black)
+
+            Button(action: {
+                isLoggedIn = true
+            }) {
+                Text("Log in")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+
+            Button(action: {
+                withAnimation { showRegistration = true }
+            }) {
+                Text("Register")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.gray.opacity(0.2))
+                    .foregroundColor(.blue)
+                    .cornerRadius(10)
+            }
+        }
+    }
+
+    // Registration form with placeholder fields
+    private var registrationForm: some View {
+        VStack(spacing: 12) {
+            Text("Create Account")
+                .font(.headline)
+                .foregroundColor(.black)
+
+            Group {
+                TextField("Full name", text: $fullName)
+                TextField("Email", text: $email)
+                SecureField("Password", text: $password)
+                TextField("Liked sport", text: $likedSport)
+                TextField("Sport level", text: $sportLevel)
+            }
+            .textFieldStyle(.roundedBorder)
+
+            Toggle("Agree to Terms and Conditions", isOn: $agreeTerms)
+            Toggle("Subscribe to Newsletter", isOn: $subscribeNews)
+
+            Button(action: {
+                isLoggedIn = true
+            }) {
+                Text("Register")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+
+            Button(action: {
+                withAnimation { showRegistration = false }
+            }) {
+                Text("Back to Login")
+                    .frame(maxWidth: .infinity)
+                    .padding()
             }
         }
     }

--- a/QuicksportsApp/WelcomeView.swift
+++ b/QuicksportsApp/WelcomeView.swift
@@ -15,8 +15,7 @@ struct WelcomeView: View {
     var body: some View {
         if isActive {
             if isLoggedIn {
-//                HomeView()
-                LoginView()
+                HomeView()
             } else {
                 LoginView()
             }


### PR DESCRIPTION
## Summary
- make login screen switch between login and registration
- add placeholder registration fields
- show HomeView after logging in

## Testing
- `swiftc QuicksportsApp/LoginView.swift -o /tmp/login` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_687f50fb2b3083208e584271619daef4