### PR TITLE
Add login and registration UI

### DIFF
--- a/QuicksportsApp/LoginView.swift
+++ b/QuicksportsApp/LoginView.swift
@@ -8,54 +8,102 @@ import SwiftUI
 
 struct LoginView: View {
     @AppStorage("isLoggedIn") private var isLoggedIn = false
+    @State private var showRegisterForm = false
+
+    @State private var fullName = ""
+    @State private var email = ""
+    @State private var password = ""
+    @State private var likedSport = ""
+    @State private var sportLevel = ""
+    @State private var agreeTerms = false
+    @State private var subscribeNewsletter = false
 
     var body: some View {
         ZStack {
-            // Background image (with logo already inside)
             Image("LoginBackground")
                 .resizable()
                 .scaledToFill()
                 .ignoresSafeArea()
 
-            // White rounded panel with login controls
             VStack {
                 Spacer()
 
-                VStack(spacing: 16) {
-                    Text("Log in to The QuickSport")
-                        .font(.headline)
-                        .foregroundColor(.black)
+                if showRegisterForm {
+                    ScrollView {
+                        VStack(spacing: 16) {
+                            Text("Register")
+                                .font(.headline)
+                                .foregroundColor(.black)
 
-                    Button(action: {
-                        isLoggedIn = true
-                    }) {
-                        HStack {
-                            Image(systemName: "globe")
-                            Text("Log in with Google")
+                            TextField("Full Name", text: $fullName)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                            TextField("Email", text: $email)
+                                .keyboardType(.emailAddress)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                            SecureField("Password", text: $password)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                            TextField("Liked Sport", text: $likedSport)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                            TextField("Level", text: $sportLevel)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+
+                            Toggle("Agree to Terms and Conditions", isOn: $agreeTerms)
+                            Toggle("Subscribe to Newsletter", isOn: $subscribeNewsletter)
+
+                            Button(action: { isLoggedIn = true }) {
+                                Text("Register")
+                                    .frame(maxWidth: .infinity)
+                                    .padding()
+                                    .background(Color.blue)
+                                    .foregroundColor(.white)
+                                    .cornerRadius(10)
+                            }
+
+                            Button(action: { showRegisterForm = false }) {
+                                Text("Back to Login")
+                                    .frame(maxWidth: .infinity)
+                                    .padding()
+                                    .background(Color.gray.opacity(0.2))
+                                    .cornerRadius(10)
+                            }
                         }
-                        .frame(maxWidth: .infinity)
                         .padding()
-                        .background(Color(.systemGray6))
-                        .cornerRadius(10)
                     }
+                    .background(Color.white.opacity(0.95))
+                    .cornerRadius(20)
+                    .padding()
+                } else {
+                    VStack(spacing: 16) {
+                        Text("Welcome to QuickSport")
+                            .font(.headline)
+                            .foregroundColor(.black)
 
-                    Divider()
+                        Button(action: { isLoggedIn = true }) {
+                            Text("Login")
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.blue)
+                                .foregroundColor(.white)
+                                .cornerRadius(10)
+                        }
 
-                    Button(action: {
-                        isLoggedIn = true
-                    }) {
-                        Text("Log in")
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(Color.blue)
-                            .foregroundColor(.white)
-                            .cornerRadius(10)
+                        Button(action: { showRegisterForm = true }) {
+                            Text("Register")
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.gray.opacity(0.2))
+                                .cornerRadius(10)
+                        }
                     }
+                    .padding()
+                    .background(Color.white.opacity(0.95))
+                    .cornerRadius(20)
+                    .padding()
                 }
-                .padding()
-                .background(Color.white.opacity(0.95))
-                .cornerRadius(20)
-                .padding()
 
                 Spacer().frame(height: 40)
             }

--- a/QuicksportsApp/WelcomeView.swift
+++ b/QuicksportsApp/WelcomeView.swift
@@ -15,8 +15,7 @@ struct WelcomeView: View {
     var body: some View {
         if isActive {
             if isLoggedIn {
-//                HomeView()
-                LoginView()
+                HomeView()
             } else {
                 LoginView()
             }


### PR DESCRIPTION
## Summary
- improve login screen
- add a simple registration form
- show `HomeView` when logged in

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_687f50fb2b3083208e584271619daef4