### PR TITLE
Refactor navigation to RootView and main tab layout

### DIFF
--- a/QuicksportsApp/AppKeys.swift
+++ b/QuicksportsApp/AppKeys.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum AppKeys {
+    static let isLoggedIn = "isLoggedIn"
+}

--- a/QuicksportsApp/LoginView.swift
+++ b/QuicksportsApp/LoginView.swift
@@ -7,58 +7,55 @@
 import SwiftUI
 
 struct LoginView: View {
-    @AppStorage("isLoggedIn") private var isLoggedIn = false
-    @State private var showRegister = false
+    @AppStorage(AppKeys.isLoggedIn) private var isLoggedIn = false
 
     var body: some View {
-        ZStack {
-            // Background image (with logo already inside)
-            Image("LoginBackground")
-                .resizable()
-                .scaledToFill()
-                .ignoresSafeArea()
+        NavigationStack {
+            ZStack {
+                // Background image (with logo already inside)
+                Image("LoginBackground")
+                    .resizable()
+                    .scaledToFill()
+                    .ignoresSafeArea()
 
-            // White rounded panel with login controls
-            VStack {
-                Spacer()
+                // White rounded panel with login controls
+                VStack {
+                    Spacer()
 
-                VStack(spacing: 16) {
-                    Text("Welcome to QuickSport")
-                        .font(.headline)
-                        .foregroundColor(.black)
+                    VStack(spacing: 16) {
+                        Text("Welcome to QuickSport")
+                            .font(.headline)
+                            .foregroundColor(.black)
 
-                    Button(action: {
-                        isLoggedIn = true
-                    }) {
-                        Text("Login")
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(Color.blue)
-                            .foregroundColor(.white)
-                            .cornerRadius(10)
+                        Button(action: {
+                            isLoggedIn = true
+                        }) {
+                            Text("Login")
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.blue)
+                                .foregroundColor(.white)
+                                .cornerRadius(10)
+                        }
+
+                        NavigationLink(destination: RegisterStepOneView()) {
+                            Text("Register")
+                                .frame(maxWidth: .infinity)
+                                .padding()
+                                .background(Color.green)
+                                .foregroundColor(.white)
+                                .cornerRadius(10)
+                        }
                     }
+                    .padding()
+                    .background(Color.white.opacity(0.95))
+                    .cornerRadius(20)
+                    .padding()
 
-                    Button(action: {
-                        showRegister = true
-                    }) {
-                        Text("Register")
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(Color.green)
-                            .foregroundColor(.white)
-                            .cornerRadius(10)
-                    }
+                    Spacer().frame(height: 40)
                 }
-                .padding()
-                .background(Color.white.opacity(0.95))
-                .cornerRadius(20)
-                .padding()
-
-                Spacer().frame(height: 40)
             }
-        }
-        .sheet(isPresented: $showRegister) {
-            RegisterStepOneView()
+            .navigationBarHidden(true)
         }
     }
 }

--- a/QuicksportsApp/MainTabView.swift
+++ b/QuicksportsApp/MainTabView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            HomeView()
+                .tabItem {
+                    Label("Home", systemImage: "house.fill")
+                }
+
+            PlaceholderView(title: "Explore")
+                .tabItem {
+                    Label("Explore", systemImage: "safari")
+                }
+
+            PlaceholderView(title: "Bookings")
+                .tabItem {
+                    Label("Bookings", systemImage: "calendar")
+                }
+
+            ProfileView()
+                .tabItem {
+                    Label("Profile", systemImage: "person.circle")
+                }
+        }
+    }
+}
+
+private struct PlaceholderView: View {
+    let title: String
+
+    var body: some View {
+        VStack {
+            Text("\(title) Coming Soon")
+                .font(.title2)
+                .padding()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
+    }
+}
+
+private struct ProfileView: View {
+    @AppStorage(AppKeys.isLoggedIn) private var isLoggedIn = false
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("Profile")
+                .font(.largeTitle)
+                .bold()
+
+            Button {
+                isLoggedIn = false
+            } label: {
+                Text("Logout")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.red)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
+            }
+            .padding(.horizontal)
+
+            Spacer()
+        }
+        .padding(.top, 40)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(.systemBackground))
+    }
+}
+
+#Preview {
+    MainTabView()
+}

--- a/QuicksportsApp/QuicksportsAppApp.swift
+++ b/QuicksportsApp/QuicksportsAppApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct QuicksportsAppApp: App {
     var body: some Scene {
         WindowGroup {
-            WelcomeView()
+            RootView()
         }
     }
 }

--- a/QuicksportsApp/RegisterStepOneView.swift
+++ b/QuicksportsApp/RegisterStepOneView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct RegisterStepOneView: View {
     @State private var email = ""
     @State private var password = ""
-    @State private var goToNextStep = false
 
     var body: some View {
         VStack(spacing: 40) {
@@ -21,7 +20,7 @@ struct RegisterStepOneView: View {
                     .padding()
                     .background(Color(.secondarySystemBackground))
                     .cornerRadius(10)
-                
+
                 SecureField("Password", text: $password)
                     .padding()
                     .background(Color(.secondarySystemBackground))
@@ -62,21 +61,24 @@ struct RegisterStepOneView: View {
 
             Spacer()
 
-            // Continue to next page
-            NavigationLink(destination: RegisterStepTwoView(), isActive: $goToNextStep) {
-                Button("Continue") {
-                    goToNextStep = true
-                }
-                .frame(maxWidth: .infinity)
-                .padding()
-                .background(Color.blue)
-                .foregroundColor(.white)
-                .cornerRadius(10)
+            NavigationLink(destination: RegisterStepTwoView()) {
+                Text("Continue")
+                    .frame(maxWidth: .infinity)
+                    .padding()
+                    .background(Color.blue)
+                    .foregroundColor(.white)
+                    .cornerRadius(10)
             }
             .padding(.horizontal, 32)
             .padding(.bottom, 20)
         }
         .navigationTitle("Register")
         .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        RegisterStepOneView()
     }
 }

--- a/QuicksportsApp/RegisterStepTwoView.swift
+++ b/QuicksportsApp/RegisterStepTwoView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 struct RegisterStepTwoView: View {
     @State private var fullName = ""
     @State private var likedSport = ""
+    @AppStorage(AppKeys.isLoggedIn) private var isLoggedIn = false
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
         VStack(spacing: 20) {
@@ -10,15 +12,31 @@ struct RegisterStepTwoView: View {
                 .padding()
                 .background(Color(.secondarySystemBackground))
                 .cornerRadius(10)
-            
+
             TextField("Liked Sport", text: $likedSport)
                 .padding()
                 .background(Color(.secondarySystemBackground))
                 .cornerRadius(10)
 
             Spacer()
+
+            Button("Finish") {
+                isLoggedIn = true
+                dismiss()
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.blue)
+            .foregroundColor(.white)
+            .cornerRadius(10)
         }
         .padding()
         .navigationTitle("More Info")
+    }
+}
+
+#Preview {
+    NavigationStack {
+        RegisterStepTwoView()
     }
 }

--- a/QuicksportsApp/RootView.swift
+++ b/QuicksportsApp/RootView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct RootView: View {
+    @AppStorage(AppKeys.isLoggedIn) private var isLoggedIn = false
+    @State private var showSplash = true
+    @State private var splashOpacity = 1.0
+
+    var body: some View {
+        ZStack {
+            if isLoggedIn {
+                MainTabView()
+            } else {
+                LoginView()
+            }
+
+            if showSplash {
+                SplashView()
+                    .opacity(splashOpacity)
+                    .transition(.opacity)
+            }
+        }
+        .onAppear(perform: startSplash)
+    }
+
+    private func startSplash() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            withAnimation(.easeOut(duration: 0.3)) {
+                splashOpacity = 0.0
+            }
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+            withAnimation {
+                showSplash = false
+            }
+        }
+    }
+}
+
+#Preview {
+    RootView()
+}

--- a/QuicksportsApp/WelcomeView.swift
+++ b/QuicksportsApp/WelcomeView.swift
@@ -1,56 +1,21 @@
-//
-//  WelcomeView.swift
-//  QuicksportsApp
-//
-//  Created by Илья Невров on 07/06/2025.
-//
-
 import SwiftUI
 
-struct WelcomeView: View {
-    @AppStorage("isLoggedIn") private var isLoggedIn = false
-    @State private var isActive = false
-    @State private var opacity = 1.0
-
+struct SplashView: View {
     var body: some View {
-        if isActive {
-            if false
-            // TODO: Remove hardcoded false here for a further logic
-            {
-                HomeView()
-            } else {
-                LoginView()
-            }
-        } else {
-            // Splash screen with logo
-            VStack {
-                Spacer()
-                Image("Logo")
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 250, height: 250)
-                    .opacity(opacity)
-                Spacer()
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color.white)
-            .ignoresSafeArea()
-            .onAppear {
-                // Wait then fade out
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    withAnimation(.easeOut(duration: 0.3)) {
-                        opacity = 0.0
-                    }
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
-                    isActive = true
-                }
-            }
+        VStack {
+            Spacer()
+            Image("Logo")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 250, height: 250)
+            Spacer()
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color.white)
+        .ignoresSafeArea()
     }
-
 }
 
 #Preview {
-    WelcomeView()
+    SplashView()
 }


### PR DESCRIPTION
## Summary
- add AppKeys helpers and new RootView to centralize splash, auth, and main routing
- implement MainTabView with home, placeholder tabs, and profile logout
- simplify auth and splash flows, updating login/register navigation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ea6388f648320882f0d6c7ef5ed5b)