### PR TITLE
Add events list cards to Explore tab

### DIFF
--- a/QuicksportsApp/EventsListView.swift
+++ b/QuicksportsApp/EventsListView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+struct EventsListView: View {
+    private let columns = [GridItem(.adaptive(minimum: 360), spacing: 16)]
+
+    var body: some View {
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: 16) {
+                ForEach(Match.sampleMatches) { match in
+                    MatchCardView(match: match)
+                }
+            }
+            .padding()
+        }
+        .background(Color(.systemGroupedBackground))
+        .navigationTitle("Explore")
+    }
+}
+
+struct MatchCardView: View {
+    let match: Match
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            AsyncImage(url: match.locationImageURL) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFill()
+                case .failure(_):
+                    placeholder
+                case .empty:
+                    placeholder
+                @unknown default:
+                    placeholder
+                }
+            }
+            .frame(width: 96, height: 96)
+            .background(Color(.systemGray5))
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+
+            VStack(alignment: .leading, spacing: 8) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(match.name)
+                        .font(.headline)
+                        .fontWeight(.semibold)
+                    Text(match.formattedDate)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+
+                HStack(spacing: 8) {
+                    PillView(text: match.city, icon: "mappin.and.ellipse")
+                    PillView(text: "3", style: .secondary)
+                        .frame(height: 24)
+                }
+
+                HStack(spacing: 8) {
+                    PillView(text: match.playersText, icon: "person.2.fill", style: .info)
+                    PillView(text: match.status.rawValue, style: match.status == .confirmed ? .success : .warning)
+                    PillView(text: "€\(match.formattedPrice)", icon: "eurosign.circle.fill", style: .info)
+                    PillView(text: "\(match.formattedDuration) h", icon: "clock.fill", style: .neutral)
+
+                    if let discount = match.discountPercent, let oldPrice = match.oldPrice {
+                        DiscountPillView(discount: discount, oldPrice: oldPrice)
+                    }
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .background(Color(.systemBackground))
+        .overlay(alignment: .topTrailing) {
+            Image(systemName: "volleyball.fill")
+                .foregroundColor(Color(.systemGray4))
+                .padding(10)
+        }
+        .overlay(
+            RoundedRectangle(cornerRadius: 18)
+                .stroke(Color(.systemGray5), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 18))
+        .shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)
+    }
+
+    private var placeholder: some View {
+        RoundedRectangle(cornerRadius: 14)
+            .fill(Color(.systemGray5))
+    }
+}
+
+struct PillView: View {
+    enum Style {
+        case neutral
+        case warning
+        case success
+        case info
+        case secondary
+
+        var foreground: Color {
+            switch self {
+            case .neutral, .secondary: return .primary
+            case .warning: return Color(.sRGB, red: 0.54, green: 0.37, blue: 0.02, opacity: 1)
+            case .success: return Color(.sRGB, red: 0.11, green: 0.48, blue: 0.21, opacity: 1)
+            case .info: return Color(.sRGB, red: 0.07, green: 0.33, blue: 0.62, opacity: 1)
+            }
+        }
+
+        var background: Color {
+            switch self {
+            case .neutral: return Color(.systemGray5)
+            case .warning: return Color(.systemYellow).opacity(0.25)
+            case .success: return Color(.systemGreen).opacity(0.2)
+            case .info: return Color(.systemBlue).opacity(0.15)
+            case .secondary: return Color(.systemGray5)
+            }
+        }
+    }
+
+    var text: String
+    var icon: String? = nil
+    var style: Style = .neutral
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if let icon {
+                Image(systemName: icon)
+                    .font(.caption)
+            }
+            Text(text)
+                .font(.caption)
+                .fontWeight(.semibold)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(style.background)
+        .foregroundColor(style.foreground)
+        .clipShape(Capsule())
+    }
+}
+
+struct DiscountPillView: View {
+    let discount: Int
+    let oldPrice: Double
+
+    var body: some View {
+        HStack(spacing: 4) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Save \(discount)% Off")
+                    .font(.caption)
+                    .fontWeight(.bold)
+                Text("€\(String(format: "%.0f", oldPrice))")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .strikethrough()
+            }
+            .padding(.leading, 10)
+            .padding(.vertical, 6)
+        }
+        .padding(.trailing, 10)
+        .background(Color(.systemBlue).opacity(0.15))
+        .foregroundColor(Color(.systemBlue))
+        .clipShape(Capsule())
+    }
+}
+
+#Preview {
+    NavigationStack {
+        EventsListView()
+    }
+}

--- a/QuicksportsApp/MainTabView.swift
+++ b/QuicksportsApp/MainTabView.swift
@@ -8,10 +8,12 @@ struct MainTabView: View {
                     Label("Home", systemImage: "house.fill")
                 }
 
-            PlaceholderView(title: "Explore")
-                .tabItem {
-                    Label("Explore", systemImage: "safari")
-                }
+            NavigationStack {
+                EventsListView()
+            }
+            .tabItem {
+                Label("Explore", systemImage: "safari")
+            }
 
             PlaceholderView(title: "Bookings")
                 .tabItem {

--- a/QuicksportsApp/Match.swift
+++ b/QuicksportsApp/Match.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+struct Match: Identifiable {
+    enum Status: String {
+        case pending = "Pending"
+        case confirmed = "Confirmed"
+    }
+
+    let id: UUID
+    let name: String
+    let gameDate: Date
+    let city: String
+    let locationImageURL: URL
+    let status: Status
+    let minPlayers: Int
+    let currentPlayers: Int
+    let price: Double
+    let durationHours: Double
+    let discountPercent: Int?
+    let oldPrice: Double?
+
+    var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, HH:mm EEE"
+        return formatter.string(from: gameDate)
+    }
+
+    var playersText: String {
+        "\(currentPlayers)/\(minPlayers)"
+    }
+
+    var formattedDuration: String {
+        if durationHours.truncatingRemainder(dividingBy: 1) == 0 {
+            return String(format: "%.0f", durationHours)
+        }
+        return String(format: "%.1f", durationHours)
+    }
+
+    var formattedPrice: String {
+        if price.truncatingRemainder(dividingBy: 1) == 0 {
+            return String(format: "%.0f", price)
+        }
+        return String(format: "%.1f", price)
+    }
+
+    static var sampleMatches: [Match] {
+        [
+            Match(
+                id: UUID(),
+                name: "Varviksweg Wed - elo 3+",
+                gameDate: DateComponents(calendar: .current, year: 2024, month: 12, day: 17, hour: 18, minute: 0).date ?? Date(),
+                city: "Enschede",
+                locationImageURL: URL(string: "https://images.pexels.com/photos/109969/pexels-photo-109969.jpeg?auto=compress&cs=tinysrgb&w=800")!,
+                status: .pending,
+                minPlayers: 10,
+                currentPlayers: 9,
+                price: 4.5,
+                durationHours: 2,
+                discountPercent: nil,
+                oldPrice: nil
+            ),
+            Match(
+                id: UUID(),
+                name: "Diekmanhal Fri - elo 3+",
+                gameDate: DateComponents(calendar: .current, year: 2024, month: 12, day: 15, hour: 19, minute: 0).date ?? Date(),
+                city: "Enschede",
+                locationImageURL: URL(string: "https://images.pexels.com/photos/4761666/pexels-photo-4761666.jpeg?auto=compress&cs=tinysrgb&w=800")!,
+                status: .confirmed,
+                minPlayers: 10,
+                currentPlayers: 10,
+                price: 6,
+                durationHours: 2,
+                discountPercent: 25,
+                oldPrice: 8
+            ),
+            Match(
+                id: UUID(),
+                name: "Pathmoshal Sunday Community Game",
+                gameDate: DateComponents(calendar: .current, year: 2024, month: 12, day: 22, hour: 16, minute: 0).date ?? Date(),
+                city: "Enschede",
+                locationImageURL: URL(string: "https://images.pexels.com/photos/2394507/pexels-photo-2394507.jpeg?auto=compress&cs=tinysrgb&w=800")!,
+                status: .pending,
+                minPlayers: 10,
+                currentPlayers: 0,
+                price: 4.5,
+                durationHours: 2,
+                discountPercent: nil,
+                oldPrice: nil
+            ),
+            Match(
+                id: UUID(),
+                name: "Community Night - elo 4+",
+                gameDate: DateComponents(calendar: .current, year: 2024, month: 12, day: 28, hour: 20, minute: 0).date ?? Date(),
+                city: "Enschede",
+                locationImageURL: URL(string: "https://images.pexels.com/photos/114296/pexels-photo-114296.jpeg?auto=compress&cs=tinysrgb&w=800")!,
+                status: .confirmed,
+                minPlayers: 12,
+                currentPlayers: 1,
+                price: 5,
+                durationHours: 1.5,
+                discountPercent: nil,
+                oldPrice: nil
+            ),
+            Match(
+                id: UUID(),
+                name: "Weekend Open Play",
+                gameDate: DateComponents(calendar: .current, year: 2024, month: 12, day: 30, hour: 15, minute: 0).date ?? Date(),
+                city: "Enschede",
+                locationImageURL: URL(string: "https://images.pexels.com/photos/3788232/pexels-photo-3788232.jpeg?auto=compress&cs=tinysrgb&w=800")!,
+                status: .pending,
+                minPlayers: 10,
+                currentPlayers: 8,
+                price: 4.5,
+                durationHours: 2,
+                discountPercent: 25,
+                oldPrice: 6
+            )
+        ]
+    }
+}


### PR DESCRIPTION
## Summary
- add Match model with sample data for events
- build EventsListView with card-style layout and reusable pill components
- replace Explore tab content with the new events list grid

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693eb5bc811883208605b0675133eb6f)