### PR TITLE
Add tab navigation with leaderboard wallet profile screens

### DIFF
--- a/QuicksportsApp/AppKeys.swift
+++ b/QuicksportsApp/AppKeys.swift
@@ -8,4 +8,5 @@ import Foundation
 
 enum AppKeys {
     static let isLoggedIn = "isLoggedIn"
+    static let walletBalance = "walletBalance"
 }

--- a/QuicksportsApp/EventsListView.swift
+++ b/QuicksportsApp/EventsListView.swift
@@ -19,7 +19,6 @@ struct EventsListView: View {
             .padding()
         }
         .background(Color(.systemGroupedBackground))
-        .navigationTitle("Explore")
     }
 }
 

--- a/QuicksportsApp/HomeView.swift
+++ b/QuicksportsApp/HomeView.swift
@@ -8,14 +8,8 @@ import SwiftUI
 
 struct HomeView: View {
     var body: some View {
-        VStack {
-            Text("🏠 Home Screen")
-                .font(.largeTitle)
-                .padding()
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color.white)
+        EventsListView()
+            .navigationTitle("Home")
     }
 }
 

--- a/QuicksportsApp/LeaderboardView.swift
+++ b/QuicksportsApp/LeaderboardView.swift
@@ -1,0 +1,51 @@
+//
+//  LeaderboardView.swift
+//  QuicksportsApp
+//
+//  Created by Илья Невров on 14/12/2025.
+//
+
+import SwiftUI
+
+struct LeaderboardView: View {
+    private let players: [(name: String, score: Int)] = [
+        ("Alex Morgan", 980),
+        ("Sam Rivera", 965),
+        ("Taylor Kim", 952),
+        ("Jordan Lee", 940),
+        ("Casey Patel", 928),
+        ("Riley Chen", 917),
+        ("Jamie Brown", 905),
+        ("Morgan Diaz", 892),
+        ("Quinn Davis", 881),
+        ("Parker Evans", 870)
+    ]
+
+    var body: some View {
+        List(Array(players.enumerated()), id: \.offset) { index, player in
+            HStack {
+                Text("\(index + 1)")
+                    .font(.headline)
+                    .frame(width: 30, alignment: .leading)
+                VStack(alignment: .leading) {
+                    Text(player.name)
+                        .font(.body)
+                        .fontWeight(.semibold)
+                    Text("Score: \(player.score)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            .padding(.vertical, 8)
+        }
+        .listStyle(.insetGrouped)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        LeaderboardView()
+            .navigationTitle("Leaderboard")
+    }
+}

--- a/QuicksportsApp/MainTabView.swift
+++ b/QuicksportsApp/MainTabView.swift
@@ -9,72 +9,37 @@ import SwiftUI
 struct MainTabView: View {
     var body: some View {
         TabView {
-            HomeView()
-                .tabItem {
-                    Label("Home", systemImage: "house.fill")
-                }
-
             NavigationStack {
-                EventsListView()
+                HomeView()
             }
             .tabItem {
-                Label("Explore", systemImage: "safari")
+                Label("Home", systemImage: "house.fill")
             }
 
-            PlaceholderView(title: "Bookings")
-                .tabItem {
-                    Label("Bookings", systemImage: "calendar")
-                }
-
-            ProfileView()
-                .tabItem {
-                    Label("Profile", systemImage: "person.circle")
-                }
-        }
-    }
-}
-
-private struct PlaceholderView: View {
-    let title: String
-
-    var body: some View {
-        VStack {
-            Text("\(title) Coming Soon")
-                .font(.title2)
-                .padding()
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(.systemBackground))
-    }
-}
-
-private struct ProfileView: View {
-    @AppStorage(AppKeys.isLoggedIn) private var isLoggedIn = false
-
-    var body: some View {
-        VStack(spacing: 24) {
-            Text("Profile")
-                .font(.largeTitle)
-                .bold()
-
-            Button {
-                isLoggedIn = false
-            } label: {
-                Text("Logout")
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.red)
-                    .foregroundColor(.white)
-                    .cornerRadius(10)
+            NavigationStack {
+                LeaderboardView()
+                    .navigationTitle("Leaderboard")
             }
-            .padding(.horizontal)
+            .tabItem {
+                Label("Leaderboard", systemImage: "trophy.fill")
+            }
 
-            Spacer()
+            NavigationStack {
+                WalletView()
+                    .navigationTitle("Wallet")
+            }
+            .tabItem {
+                Label("Wallet", systemImage: "wallet.pass")
+            }
+
+            NavigationStack {
+                ProfileView()
+                    .navigationTitle("Profile")
+            }
+            .tabItem {
+                Label("Profile", systemImage: "person.circle")
+            }
         }
-        .padding(.top, 40)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(Color(.systemBackground))
     }
 }
 

--- a/QuicksportsApp/ProfileView.swift
+++ b/QuicksportsApp/ProfileView.swift
@@ -1,0 +1,136 @@
+//
+//  ProfileView.swift
+//  QuicksportsApp
+//
+//  Created by Илья Невров on 14/12/2025.
+//
+
+import SwiftUI
+
+struct ProfileView: View {
+    @AppStorage(AppKeys.isLoggedIn) private var isLoggedIn = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                topRow
+                eloCard
+                logoutButton
+            }
+            .padding()
+        }
+        .background(Color(.systemGroupedBackground))
+    }
+
+    private var topRow: some View {
+        HStack(alignment: .top, spacing: 16) {
+            Circle()
+                .fill(Color(.systemGray5))
+                .frame(width: 72, height: 72)
+                .overlay {
+                    Image(systemName: "person.fill")
+                        .font(.title)
+                        .foregroundStyle(.secondary)
+                }
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Hi Ilia Nevrov, welcome!")
+                    .font(.headline)
+                Text("ilia.nevrov@example.com")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            VStack(spacing: 8) {
+                Button {
+                } label: {
+                    Text("Edit profile")
+                        .font(.subheadline)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(Color(.systemGray5))
+                        .foregroundColor(.primary)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+
+                NavigationLink(destination: WalletView().navigationTitle("Wallet")) {
+                    Text("Wallet")
+                        .font(.subheadline)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 8)
+                        .background(Color(.systemBlue))
+                        .foregroundColor(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 10))
+                }
+            }
+        }
+        .padding()
+        .background(Color(.systemBackground))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color(.systemGray5), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    private var eloCard: some View {
+        VStack(spacing: 16) {
+            Text("Total ELO: 4.12")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            HStack(spacing: 0) {
+                eloStat(icon: "soccerball", value: "-")
+                Divider()
+                eloStat(icon: "volleyball", value: "4.12")
+                Divider()
+                eloStat(icon: "basketball", value: "-")
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(Color(.systemBackground))
+        .overlay(
+            RoundedRectangle(cornerRadius: 16)
+                .stroke(Color(.systemGray5), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    private func eloStat(icon: String, value: String) -> some View {
+        VStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text(value)
+                .font(.headline)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 4)
+    }
+
+    private var logoutButton: some View {
+        Button {
+            isLoggedIn = false
+        } label: {
+            Text("Logout")
+                .font(.headline)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color(.systemRed))
+                .foregroundColor(.white)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+        .padding(.top, 8)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ProfileView()
+            .navigationTitle("Profile")
+    }
+}

--- a/QuicksportsApp/WalletView.swift
+++ b/QuicksportsApp/WalletView.swift
@@ -1,0 +1,44 @@
+//
+//  WalletView.swift
+//  QuicksportsApp
+//
+//  Created by Илья Невров on 14/12/2025.
+//
+
+import SwiftUI
+
+struct WalletView: View {
+    @AppStorage(AppKeys.walletBalance) private var balance: Double = 0.0
+    @State private var topUpAmount: String = ""
+
+    var body: some View {
+        Form {
+            Section(header: Text("Your balance")) {
+                Text("€\(balance, specifier: "%.2f")")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+            }
+
+            Section(header: Text("Top up")) {
+                TextField("Amount", text: $topUpAmount)
+                    .keyboardType(.decimalPad)
+
+                Button("Top up", action: topUp)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+    }
+
+    private func topUp() {
+        guard let amount = Double(topUpAmount), amount > 0 else { return }
+        balance += amount
+        topUpAmount = ""
+    }
+}
+
+#Preview {
+    NavigationStack {
+        WalletView()
+            .navigationTitle("Wallet")
+    }
+}


### PR DESCRIPTION
## Summary
- replace explore and placeholder tabs with home, leaderboard, wallet, and profile tabs wrapped in navigation stacks
- add dedicated leaderboard, wallet, and profile screens with required UI and behaviors
- connect home tab to event list while keeping navigation logic intact

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693ebff79b788320b6e33d4dfb3339d2)